### PR TITLE
Allow clj-v8 to be bundled in an uberjar

### DIFF
--- a/clj-v8/src/v8/core.clj
+++ b/clj-v8/src/v8/core.clj
@@ -13,6 +13,10 @@
       ["Linux" "x86_64"]    ["linux/x86_64/" ".so"]
       ["Linux" "amd64"]     ["linux/x86_64/" ".so"]
       ["Linux" "x86"]       ["linux/x86/" ".so"]
+      ["Linux" "i386"]      ["linux/x86/" ".so"]
+      ["Linux" "i486"]      ["linux/x86/" ".so"]
+      ["Linux" "i586"]      ["linux/x86/" ".so"]
+      ["Linux" "i686"]      ["linux/x86/" ".so"]
       (throw (Exception. (str "Unsupported OS/archetype: " os-name " " os-arch))))))
 
 (defn load-library-from-class-path


### PR DESCRIPTION
- clj-v8 fails in an uberjar, since it relies on its files to be
  accessible on the file system.
- this is because JNI and JNA relies on the native binaries to be on the
  file system.
- so in order to be bundled in an uberjar, we have to copy the files out
  to a temporary location when loading the native library.

The entire investigation can be read for your amusement or horror in https://github.com/circleci/stefon/issues/9.

I have not been able to run your tests - since that too results in a UnsatisfiedLinkError (see #6), but I have packaged this version in our uberjar, and that works.
