### PR TITLE
Guard against reloading native v8 library

### DIFF
--- a/clj-v8/src/v8/core.clj
+++ b/clj-v8/src/v8/core.clj
@@ -4,6 +4,8 @@
   (:import [com.sun.jna WString Native Memory Pointer NativeLibrary]
            [java.io File FileOutputStream]))
 
+(declare LIBRARY)
+
 (defn- find-file-path-fragments
   []
   (let [os-name (System/getProperty "os.name")
@@ -33,12 +35,13 @@
     (System/load (.getAbsolutePath tmp))
     (.deleteOnExit tmp)))
 
-(try
-  (System/loadLibrary "v8wrapper")
-  (catch UnsatisfiedLinkError e
-    (load-library-from-class-path "libv8" ".clj-v8")
-    (load-library-from-class-path "libv8wrapper" "")
-    (System/setProperty "jna.library.path" (System/getProperty "java.io.tmpdir"))))
+(when-not (bound? #'LIBRARY)
+  (try
+    (System/loadLibrary "v8wrapper")
+    (catch UnsatisfiedLinkError e
+      (load-library-from-class-path "libv8" ".clj-v8")
+      (load-library-from-class-path "libv8wrapper" "")
+      (System/setProperty "jna.library.path" (System/getProperty "java.io.tmpdir")))))
 
 (def LIBRARY (com.sun.jna.NativeLibrary/getInstance "v8wrapper"))
 


### PR DESCRIPTION
The v8wrapper native object only needs to be loaded once; in fact, it must not be reloaded (see magnars/optimus#47).

In Java-land, I understand the loading sequence is usually protected by referencing the library instance as a static property. In Clojure, something effectively similar can be accomplished by conditionally loading the library (only when `LIBRARY` is unbound), so namespace reloading is safe.

Thoughts?